### PR TITLE
Add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add git
 WORKDIR /go/src/app
 COPY . .
 RUN go get -v
+RUN go generate
 RUN go build
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# multi-stage build dockerfile:
+# first build the app binary
+# then put it into a light final image to deploy it
+
+FROM golang:alpine as build
+RUN apk update && apk add git
+WORKDIR /go/src/app
+COPY . .
+RUN go get -v
+RUN go build
+
+FROM alpine:latest
+RUN mkdir /books
+COPY --from=build /go/src/app/app /app
+ENTRYPOINT ["/app", "-bookdir", "/books"]


### PR DESCRIPTION
It would be nice to have it available on the Docker hub as an automated build, too.

I have pushed the resulting docker image to my personal repo on docker hub to test and deploy BookBrowser for the meantime.

I run it using docker stack and traefik:

```yaml
version: '3.3'

services:
  bookbrowser:
    image: mathieui/bookbrowser:latest
    networks:
      - default
      - web
    ports:
      - "8090"
    volumes:
      - /data/books:/books
    labels:
      - "traefik.backend=bookbrowser-app"
      - "traefik.docker.network=web"
      - "traefik.frontend.rule=Host:books.example.com"
      - "traefik.enable=true"
      - "traefik.port=8090"
      - "traefik.default.protocol=http"
      - "traefik.frontend.auth.basic=<user:password htpasswd payload>"

networks:
  web:
    external: true
```