### PR TITLE
Handle unset GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifndef $$GOPATH
+ifndef GOPATH
   export GOPATH=${HOME}/go
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef $$GOPATH
+  export GOPATH=${HOME}/go
+endif
+
 .PHONY: default
 default: clean build-deps deps generate test build
 


### PR DESCRIPTION
Even though Go itself defaults to `~/go` when `GOPATH` is not set, some of the dependencies do not use the same default. This change helps by providing a default in the Makefile.