### PR TITLE
Index caching

### DIFF
--- a/bookbrowser.go
+++ b/bookbrowser.go
@@ -117,6 +117,7 @@ func main() {
 
 	s := server.NewServer(*addr, *bookdir, *tempdir, curversion, true, *nocovers)
 	go func() {
+		s.LoadBookIndex()
 		s.RefreshBookIndex()
 		if len(s.Indexer.BookList()) == 0 {
 			log.Fatalln("Fatal error: no books found")

--- a/indexer/seencache.go
+++ b/indexer/seencache.go
@@ -1,0 +1,48 @@
+package indexer
+
+import (
+	"fmt"
+	"crypto/sha1"
+	"time"
+)
+
+type SeenCache struct {
+	seen map[string]int
+}
+
+func NewSeenCache() *SeenCache {
+	return &SeenCache{seen: make(map[string]int)}
+}
+
+func (c *SeenCache) Hash(filePath string, fileSize int64, modTime time.Time) string {
+	token := fmt.Sprintf("%08d|%s|%s",fileSize,modTime,filePath)
+	return fmt.Sprintf("%x", sha1.Sum([]byte(token)))[:10]
+}
+
+func (c *SeenCache) Clear() {
+	c.seen = make(map[string]int)
+}
+
+func (c *SeenCache) Add(filePath string, fileSize int64, modTime time.Time, index int) string {
+	hash := c.Hash(filePath, fileSize, modTime)
+	c.seen[hash] = index
+	return hash
+}
+
+func (c *SeenCache) AddHash(hash string, index int) {
+	c.seen[hash] = index
+}
+
+func (c *SeenCache) Seen(filePath string, fileSize int64, modTime time.Time) (bool, string, int) {
+	hash := c.Hash(filePath, fileSize, modTime)
+	if index, exists := c.seen[hash]; exists {
+		return true, hash, index
+	} else {
+		return false, "", -1
+	}
+}
+
+func (c *SeenCache) SeenHash(hash string) (bool, int) {
+	index, exists := c.seen[hash]
+	return exists, index
+}

--- a/server/server.go
+++ b/server/server.go
@@ -75,6 +75,13 @@ func (s *Server) printLog(format string, v ...interface{}) {
 	}
 }
 
+func (s *Server) LoadBookIndex() error {
+	return s.Indexer.Load()
+}
+func (s *Server) SaveBookIndex() error {
+	return s.Indexer.Save()
+}
+
 // RefreshBookIndex refreshes the book index
 func (s *Server) RefreshBookIndex() error {
 	errs, err := s.Indexer.Refresh()
@@ -91,6 +98,13 @@ func (s *Server) RefreshBookIndex() error {
 	}
 
 	debug.FreeOSMemory()
+
+	err = s.Indexer.Save()
+	if err != nil {
+		log.Printf("Error saving index: %s",err)
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added support for saving the index to a simple JSON file after each indexing job, and loading it (followed by a quick refresh) at the next startup. This allows the book library to be populated immediately at startup, rather than waiting a potentially long time for the initial indexing job to complete.

The index file is saved as index.json in the existing cover path.

There's a lot of room for improvement here; this was a quick implementation to eliminate the 15-minute-plus delay at each startup while BookBrowser indexed my tens of thousands of ebooks stored on a remote filesystem.