### PR TITLE
Implement pagination support

### DIFF
--- a/booklist/authorlist.go
+++ b/booklist/authorlist.go
@@ -28,3 +28,17 @@ func (al AuthorList) Sorted(less func(a, b struct{ Name, ID string }) bool) Auth
 	})
 	return nal
 }
+
+func (al AuthorList) Skip(n int) AuthorList {
+	if n >= len(al) {
+		return AuthorList{}
+	}
+	return al[n:]
+}
+
+func (al AuthorList) Take(n int) AuthorList {
+	if n > len(al) {
+		return al
+	}
+	return al[:n]
+}

--- a/booklist/serieslist.go
+++ b/booklist/serieslist.go
@@ -28,3 +28,17 @@ func (sl SeriesList) Sorted(less func(a, b struct{ Name, ID string }) bool) Seri
 	})
 	return nsl
 }
+
+func (sl SeriesList) Skip(n int) SeriesList {
+	if n >= len(sl) {
+		return SeriesList{}
+	}
+	return sl[n:]
+}
+
+func (sl SeriesList) Take(n int) SeriesList {
+	if n > len(sl) {
+		return sl
+	}
+	return sl[:n]
+}

--- a/public/static/style.css
+++ b/public/static/style.css
@@ -627,3 +627,36 @@ a:visited {
 a:hover {
     color: #004479;
 }
+
+.pagination,
+.pagination a {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.pagination a,
+.pagination a:link,
+.pagination a:visited,
+.pagination a:active,
+.pagination a:hover {
+    text-decoration: none;
+    padding: 4px 12px;
+    border: none;
+    background: #ddd;
+    color: #000;
+    margin-right: 2px;
+}
+
+.pagination a.current {
+    font-weight: bold;
+}
+.pagination a.next:before {
+    content: "\00bb";
+}
+.pagination a.prev:before {
+    content: "\00ab";
+}

--- a/public/templates/authors.tmpl
+++ b/public/templates/authors.tmpl
@@ -3,3 +3,7 @@
 <a href="/authors/{{.ID}}" class="item">{{.Name}}</a>
 {{end}}
 </div>
+
+{{if .Authors}}
+{{template "pagination" .Pagination}}
+{{end}}

--- a/public/templates/books.tmpl
+++ b/public/templates/books.tmpl
@@ -24,4 +24,8 @@
     {{end}}
 </div>
 
-{{if not .Books}} Not found (or still indexing){{end}}
+{{if .Books}}
+{{template "pagination" .Pagination}}
+{{else}}
+Not found (or still indexing)
+{{end}}

--- a/public/templates/pagination.tmpl
+++ b/public/templates/pagination.tmpl
@@ -1,0 +1,3 @@
+	<div class="pagination">
+    {{range .Pages}}<a href="?{{.QueryString}}"{{if .Current}} class="current"{{end}}{{if .Next}} class="next"{{end}}{{if .Prev}} class="prev"{{end}}>{{if .Index}}{{.Index}}{{end}}</a>{{end}}
+    </div>

--- a/public/templates/search.tmpl
+++ b/public/templates/search.tmpl
@@ -1,7 +1,7 @@
 <br>
 {{if .Query}}
 {{if .Books}}
-<center>{{len .Books}} books found</center>
+<center>{{.Pagination.ItemTotal}} books found</center>
 {{else}}
 <center>No books were found matching your query "{{.Query}}"</center>
 {{end}}

--- a/public/templates/seriess.tmpl
+++ b/public/templates/seriess.tmpl
@@ -3,3 +3,7 @@
 <a href="/series/{{.ID}}" class="item">{{.Name}}</a>
 {{end}}
 </div>
+
+{{if .Series}}
+{{template "pagination" .Pagination}}
+{{end}}

--- a/server/pagination.go
+++ b/server/pagination.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"fmt"
+	"html/template"
+)
+
+type Pagination struct {
+	ItemOffset int
+	ItemLimit int
+	ItemTotal int
+	CurrentPage int
+	TotalPages int
+
+	queryStringFormat string
+}
+
+type Page struct {
+	Index int
+	Current bool
+	Offset int
+	Limit int
+	QueryString template.URL
+
+	Prev bool
+	Next bool
+}
+
+const defaultQueryLimit = 24		// default number of items to return, if no limit is specified; 24 is evenly divisible by the default of 4 items displayed per row
+const maxQueryLimit = 1000			// maximum number of items to return, to prevent users from doing dumb things
+
+func queryStringFormat(o url.Values) string {
+	n := url.Values{}
+	for k, v := range o {
+		if k != "offset" && k != "limit" {
+			for _, vv := range v {
+				n.Set(k, vv)
+			}
+		}
+	}
+	f := strings.Replace(n.Encode(),"%","%%", -1)
+	if len(f) != 0 {
+		f += "&"
+	}
+	f += "offset=%d&limit=%d"
+	return f
+}
+
+func NewPagination(v url.Values, totalItems int) *Pagination {
+
+	p := &Pagination{
+		queryStringFormat: queryStringFormat(v),
+		ItemTotal: totalItems,
+	}
+
+	p.ItemOffset, _ = strconv.Atoi(v.Get("offset"))
+	if p.ItemOffset < 0 {
+		p.ItemOffset = 0
+	}
+
+	p.ItemLimit, _ = strconv.Atoi(v.Get("limit"))
+	if p.ItemLimit < 1 {
+		p.ItemLimit = defaultQueryLimit
+	}
+	if p.ItemLimit > maxQueryLimit {
+		p.ItemLimit = maxQueryLimit
+	}
+
+	p.TotalPages = totalItems / p.ItemLimit
+	if totalItems % p.ItemLimit != 0 {
+		p.TotalPages++
+	}
+
+	p.CurrentPage = (p.ItemOffset+1) / p.ItemLimit
+	if (p.ItemOffset+1) % p.ItemLimit != 0 {
+		p.CurrentPage++
+	}
+
+	return p
+}
+
+func (p *Pagination) Pages() []Page {
+	pages := make([]Page,0,p.TotalPages)
+
+	if p.CurrentPage != 1 {
+		offset := p.ItemOffset - p.ItemLimit
+		if offset < 0 {
+			offset = 0
+		}
+		pages = append(pages,Page{
+			Prev: true,
+			Current: false,
+			Offset: offset,
+			Limit: p.ItemLimit,
+			QueryString: template.URL(fmt.Sprintf(p.queryStringFormat,offset,p.ItemLimit)),
+		})
+	}
+
+	for idx := 0; idx<p.TotalPages; idx++ {
+		pages = append(pages,Page{
+			Index: idx+1,
+			Current: idx+1 == p.CurrentPage,
+			Offset: idx*p.ItemLimit,
+			Limit: p.ItemLimit,
+			QueryString: template.URL(fmt.Sprintf(p.queryStringFormat,idx*p.ItemLimit,p.ItemLimit)),
+		})
+	}
+
+	if p.CurrentPage != p.TotalPages {
+		offset := p.ItemOffset + p.ItemLimit
+		pages = append(pages,Page{
+			Next: true,
+			Current: false,
+			Offset: offset,
+			Limit: p.ItemLimit,
+			QueryString: template.URL(fmt.Sprintf(p.queryStringFormat,offset,p.ItemLimit)),
+		})
+	}
+
+
+
+	return pages
+}


### PR DESCRIPTION
Paginates the book, author, and series lists, and the search results. This should help with browsing large libraries.

I'm aware that you're refactoring the server code, so I tried to keep the changes in server.go as unobtrusive as possible. Basically just an extra .Take() and .Skip() call on each slice, a call to NewPagination(), and an extra variable passed to the template renderer.